### PR TITLE
PO-2252 added pdpo named qualifier to JMS template and connection fac…

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/logging/integration/config/PdpoAsyncJmsConfig.java
+++ b/src/main/java/uk/gov/hmcts/opal/logging/integration/config/PdpoAsyncJmsConfig.java
@@ -18,7 +18,7 @@ import org.springframework.jms.support.converter.MessageType;
 @Configuration
 public class PdpoAsyncJmsConfig {
 
-    @Bean
+    @Bean("pdpoJmsConnectionFactory")
     public ConnectionFactory pdpoJmsConnectionFactory(PdpoAsyncProperties properties) {
         ServiceBusConnectionStringParser.ConnectionDetails details =
             ServiceBusConnectionStringParser.parse(properties.connectionString());
@@ -47,7 +47,7 @@ public class PdpoAsyncJmsConfig {
         return converter;
     }
 
-    @Bean
+    @Bean("pdpoJmsTemplate")
     public JmsTemplate pdpoJmsTemplate(
         ConnectionFactory pdpoJmsConnectionFactory,
         MappingJackson2MessageConverter pdpoMessageConverter,

--- a/src/main/java/uk/gov/hmcts/opal/logging/integration/service/PdpoAsyncPublisherImpl.java
+++ b/src/main/java/uk/gov/hmcts/opal/logging/integration/service/PdpoAsyncPublisherImpl.java
@@ -8,8 +8,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jms.JmsException;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.stereotype.Component;
@@ -22,11 +22,16 @@ import uk.gov.hmcts.opal.logging.integration.messaging.PdpoLogMessage;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class PdpoAsyncPublisherImpl implements PdpoAsyncPublisher {
 
     private final JmsTemplate jmsTemplate;
     private final PdpoAsyncProperties properties;
+
+    public PdpoAsyncPublisherImpl(@Qualifier("pdpoJmsTemplate") JmsTemplate jmsTemplate,
+                                  PdpoAsyncProperties properties) {
+        this.jmsTemplate = jmsTemplate;
+        this.properties = properties;
+    }
 
     @Override
     public boolean publish(PersonalDataProcessingLogDetails logDetails) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[PO-2252](https://tools.hmcts.net/jira/browse/PO-2252)


### Change description ###

We are reusing the JMS connection pattern/process used here in opal-fines-service (this is a dependancy of that project), however these beans aren't named and are causing the fines service container to get confused:

`org.springframework.beans.factory.NoUniqueBeanDefinitionException: No qualifying bean of type 'org.springframework.jms.core.JmsTemplate' available: expected single matching bean but found 2: pdpoJmsTemplate,reportPublisherJmsTemplate`

This won't change any functionality, only force spring to use the correct JMS configuration for the pdpo messaging service.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
